### PR TITLE
Run admin console on different host

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo is intended as a playground that allow testing Keycloak JS for local d
 The project uses multiple `.localhost` domains to allow proper testing across domains. Add the following to `/etc/hosts` to ensure these domains can be reached:
 
 ```
-127.0.0.1 keycloak-server.localhost kjs-playground.localhost
+127.0.0.1 keycloak-server.localhost keycloak-admin.localhost:8080 kjs-playground.localhost
 ```
 
 This project uses PNPM its package manager, to install the correct version of PNPM automatically you must first enable [Corepack](https://nodejs.org/api/corepack.html):
@@ -64,6 +64,7 @@ This command will start a server that proxies the requests from our domains to t
 Now that everything is up and running we can visit our Keycloak server and application on the following URLs:
 
 - Keycloak Server - https://keycloak-server.localhost:8080
+- Keycloak Admin Console - https://keycloak-admin.localhost:8080
 - Keycloak JS Playground - https://kjs-playground.localhost:8080
 
 Since we are using self-signed certificates it might be the case that the browser warns you about a security issue. This can be circumvented by clicking "Advanced" and then "Accept the Risk and Continue" (or a similar equivalent in your browser).

--- a/scripts/reverse-proxy.mjs
+++ b/scripts/reverse-proxy.mjs
@@ -7,6 +7,7 @@ import mkcert from 'mkcert';
 const PORT = 8080
 const PROXIES = new Map([
   ['keycloak-server.localhost:8080', 'http://127.0.0.1:8180'],
+  ['keycloak-admin.localhost:8080', 'http://127.0.0.1:8180'],
   ['kjs-playground.localhost:8080', 'http://localhost:5173'],
 ])
 
@@ -21,6 +22,7 @@ const authority = await mkcert.createCA({
 const certificate = await mkcert.createCert({
   domains: [
     'keycloak-server.localhost',
+    'keycloak-admin.localhost',
     'kjs-playground.localhost'
   ],
   validity: 365,

--- a/scripts/start-server.mjs
+++ b/scripts/start-server.mjs
@@ -28,6 +28,8 @@ async function startServer() {
       "--http-port=8180",
       "--features=admin-fine-grained-authz",
       "--proxy=edge",
+      "--hostname=https://keycloak-server.localhost:8080",
+      "--hostname-admin=https://keycloak-admin.localhost:8080",
       ...args,
     ],
     {


### PR DESCRIPTION
Runs the admin console on a different hostname in order to debug various issues that relate to proxying.